### PR TITLE
Fix the gauge creation.

### DIFF
--- a/src/spootnik/reporter.clj
+++ b/src/spootnik/reporter.clj
@@ -182,7 +182,8 @@
     (when registry
       (assert (fn? f))
       (case type
-        :gauge (gge/gauge registry (->alias alias))
+        :gauge (or (gge/gauge registry (->alias alias))
+                   (gge/gauge-fn registry (->alias alias) f))
         (throw (ex-info "invalid metric type" {})))))
   (build! [this type alias]
     (when registry


### PR DESCRIPTION
Previously function `f` was ignored. 
Now it gets registered as a part of gauge.