### PR TITLE
reporter: create a new registry even without reporters

### DIFF
--- a/src/spootnik/reporter.clj
+++ b/src/spootnik/reporter.clj
@@ -179,12 +179,11 @@
 
 (defn build-metrics
   [{:keys [reporters]} rclient]
-  (when reporters
-    (let [reg  (m/new-registry)
-          reps (build-metrics-reporters reg reporters rclient)]
-      (doseq [r reps]
-        (c/start r))
-      [reg reps])))
+  (let [reg  (m/new-registry)
+        reps (build-metrics-reporters reg reporters rclient)]
+    (doseq [r reps]
+      (c/start r))
+    [reg reps]))
 
 (defn ->alias
   [v]


### PR DESCRIPTION
There are several situations where we want a registry and no reporters:

 - use with the Ring middleware
 - use during unittests

Therefore, it is convenient to get a registry even without any reporter.